### PR TITLE
T12111: Add LinkCards extension

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -553,6 +553,10 @@ Lingo:
   path: extensions/Lingo
   repo_url: https://github.com/wikimedia/mediawiki-extensions-Lingo
   composer: true
+LinkCards:
+  branch: _branch_
+  path: extensions/LinkCards
+  repo_url: https://github.com/Wikimedia-AU/MediaWiki-extension-LinkCards
 LinkSuggest:
   branch: _branch_
   path: extensions/LinkSuggest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `LinkCards` extension, enabling users to enhance link presentation within MediaWiki.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->