### PR TITLE
Redownload SecureLinkFixer

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1028,7 +1028,6 @@ SecureLinkFixer:
   branch: _branch_
   path: extensions/SecureLinkFixer
   repo_url: https://github.com/wikimedia/mediawiki-extensions-SecureLinkFixer
-  removed: true
 SecurePoll:
   branch: _branch_
   path: extensions/SecurePoll


### PR DESCRIPTION
To fix deploys. This doesn't actually re-enable the extension, just ensures it is installed in the extensions folder