### PR TITLE
Pin InterwikiSorting to REL1_39 branch

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -521,7 +521,7 @@ InterwikiDispatcher:
   path: extensions/InterwikiDispatcher
   repo_url: https://github.com/Markus-Rost/InterwikiDispatcher
 InterwikiSorting:
-  branch: _branch_
+  branch: REL1_39
   path: extensions/InterwikiSorting
   repo_url: https://github.com/wikimedia/mediawiki-extensions-InterwikiSorting
 JSBreadCrumbs:


### PR DESCRIPTION
The master branch & REL1_44 branch don't support MW 1.43 or less.