### PR TITLE
Switch Citizen to REL1_39 branch

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -143,7 +143,7 @@ CiteThisPage:
   path: extensions/CiteThisPage
   repo_url: https://github.com/wikimedia/mediawiki-extensions-CiteThisPage
 Citizen:
-  branch: main
+  branch: REL1_39
   path: skins/Citizen
   repo_url: https://github.com/StarCitizenTools/mediawiki-skins-Citizen
 CleanChanges:


### PR DESCRIPTION
Main branch requires MW 1.43+. We currently use MW 1.42 so have to use REL1_39 to support it.