### PR TITLE
Use main branch for ThemeToggle

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1198,7 +1198,7 @@ Theme:
   path: extensions/Theme
   repo_url: https://github.com/wikimedia/mediawiki-extensions-Theme
 ThemeToggle:
-  branch: _branch_
+  branch: main
   path: extensions/ThemeToggle
   repo_url: https://github.com/wiki-gg-oss/mediawiki-extensions-ThemeToggle
 Tilesheets:


### PR DESCRIPTION
There's no REL1_42 or REL1_43 branches for this extension.