### PR TITLE
install EditSimilar per T13286

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -332,6 +332,10 @@ Editcount:
   branch: _branch_
   path: extensions/Editcount
   repo_url: https://github.com/wikimedia/mediawiki-extensions-Editcount
+EditSimilar:
+  branch: _branch_
+  path: extensions/EditSimilar
+  repo_url: https://github.com/wikimedia/mediawiki-extensions-EditSimilar
 Elastica:
   branch: _branch_
   path: extensions/Elastica

--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -324,6 +324,10 @@ EditCountNeue:
   branch: _branch_
   path: extensions/EditCountNeue
   repo_url: https://github.com/AlPha5130/mediawiki-extensions-EditCountNeue
+EditSimilar:
+  branch: _branch_
+  path: extensions/EditSimilar
+  repo_url: https://github.com/wikimedia/mediawiki-extensions-EditSimilar
 EditSubpages:
   branch: _branch_
   path: extensions/EditSubpages
@@ -332,10 +336,6 @@ Editcount:
   branch: _branch_
   path: extensions/Editcount
   repo_url: https://github.com/wikimedia/mediawiki-extensions-Editcount
-EditSimilar:
-  branch: _branch_
-  path: extensions/EditSimilar
-  repo_url: https://github.com/wikimedia/mediawiki-extensions-EditSimilar
 Elastica:
   branch: _branch_
   path: extensions/Elastica


### PR DESCRIPTION
Adding the EditSimilar MediaWiki extension from [T13286](https://issue-tracker.miraheze.org/T13286).