### PR TITLE
Use main for Citizen

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -151,7 +151,7 @@ CiteThisPage:
   path: extensions/CiteThisPage
   repo_url: https://github.com/wikimedia/mediawiki-extensions-CiteThisPage
 Citizen:
-  branch: REL1_39
+  branch: main
   path: skins/Citizen
   repo_url: https://github.com/StarCitizenTools/mediawiki-skins-Citizen
 CleanChanges:


### PR DESCRIPTION
Citizen generally doesn't use the release branch format, hence not \_branch_. main appears to support MediaWiki 1.43 now: https://github.com/StarCitizenTools/mediawiki-skins-Citizen/blob/51d5db09047ffee6a88f8809fec3f666826f1efa/skin.json#L15