### PR TITLE
install Extension:RandomImageByCategory per T12827

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -982,6 +982,10 @@ RandomImage:
   branch: master
   path: extensions/RandomImage
   repo_url: https://github.com/wikimedia/mediawiki-extensions-RandomImage
+RandomImageByCategory:
+  branch: _branch_
+  path: extensions/RandomImageByCategory
+  repo_url: https://github.com/wikimedia/mediawiki-extensions-RandomImageByCategory
 RandomSelection:
   branch: _branch_
   path: extensions/RandomSelection


### PR DESCRIPTION
Installing Extension:RandomImageByCategory per [T12827](https://issue-tracker.miraheze.org/T12827).