### PR TITLE
install RefreshSpecial per T12835

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1012,6 +1012,10 @@ Refreshed:
   branch: _branch_
   path: skins/Refreshed
   repo_url: https://github.com/wikimedia/mediawiki-skins-Refreshed
+RefreshSpecial:
+  branch: _branch_
+  path: extensions/RefreshSpecial
+  repo_url: https://github.com/wikimedia/mediawiki-extensions-RefreshSpecial
 RelatedArticles:
   branch: _branch_
   path: extensions/RelatedArticles

--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1008,14 +1008,14 @@ RealMe:
   branch: _branch_
   path: extensions/RealMe
   repo_url: https://github.com/wikimedia/mediawiki-extensions-RealMe
-Refreshed:
-  branch: _branch_
-  path: skins/Refreshed
-  repo_url: https://github.com/wikimedia/mediawiki-skins-Refreshed
 RefreshSpecial:
   branch: _branch_
   path: extensions/RefreshSpecial
   repo_url: https://github.com/wikimedia/mediawiki-extensions-RefreshSpecial
+Refreshed:
+  branch: _branch_
+  path: skins/Refreshed
+  repo_url: https://github.com/wikimedia/mediawiki-skins-Refreshed
 RelatedArticles:
   branch: _branch_
   path: extensions/RelatedArticles


### PR DESCRIPTION
Setting up the mediawiki-repos.yaml entry for [Extension:RefreshSpecial](https://www.mediawiki.org/wiki/Extension:RefreshSpecial).