### PR TITLE
Uninstall TwitterTag per T13405

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1297,6 +1297,7 @@ TwitterTag:
   branch: master
   path: extensions/TwitterTag
   repo_url: https://github.com/wikimedia/mediawiki-extensions-TwitterTag
+  removed: true
 TwoColConflict:
   branch: _branch_
   path: extensions/TwoColConflict


### PR DESCRIPTION
TwitterTag is now in a non-functional state because of the API changes at Twitter, therefore this extension is being uninstalled until further notice.