### PR TITLE
Updating Skin:Citizen branch

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -155,7 +155,7 @@ CiteThisPage:
   path: extensions/CiteThisPage
   repo_url: https://github.com/wikimedia/mediawiki-extensions-CiteThisPage
 Citizen:
-  branch: REL1_39
+  branch: main
   path: skins/Citizen
   repo_url: https://github.com/StarCitizenTools/mediawiki-skins-Citizen
 CleanChanges:


### PR DESCRIPTION
Updating the Citizen skin branch back to the main branch, I accidentally reverted it with https://github.com/miraheze/mediawiki-repos/pull/57 when installing Skin:Lakeus.