### PR TITLE
Undeploy Skin:Eveskin per T13411

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -369,10 +369,6 @@ EventStreamConfig:
   branch: _branch_
   path: extensions/EventStreamConfig
   repo_url: https://github.com/wikimedia/mediawiki-extensions-EventStreamConfig
-Eveskin:
-  branch: master
-  path: skins/Eveskin
-  repo_url: https://github.com/cforcomputer/eveskin
 ExternalData:
   branch: master
   path: extensions/ExternalData


### PR DESCRIPTION
Per [T13411](https://issue-tracker.miraheze.org/T13411), [Skin:Eveskin](https://www.mediawiki.org/wiki/Skin:Eveskin) was archived on March 25th as it hasn't been updated to work with MediaWiki 1.42 and the repository for the skin was archived by the creator, therefore it needs to be removed as it is already in a disabled state on Miraheze.