### PR TITLE
Undeploy Skin:Evelution per T13471#270359

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -353,10 +353,6 @@ EmbedVideo:
   branch: master
   path: extensions/EmbedVideo
   repo_url: https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo
-Evelution:
-  branch: main
-  path: skins/Evelution
-  repo_url: https://github.com/AWikia/SkinEvelution
 EventBus:
   branch: _branch_
   path: extensions/EventBus


### PR DESCRIPTION
Skin:Evelution has been deemed a security risk due to the conditions specified by [T13471#270359](https://issue-tracker.miraheze.org/T13471#270359).