### PR TITLE
Use REL1_43 as the branch for ThemeToggle

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1220,7 +1220,7 @@ Theme:
   path: extensions/Theme
   repo_url: https://github.com/wikimedia/mediawiki-extensions-Theme
 ThemeToggle:
-  branch: main
+  branch: REL1_43
   path: extensions/ThemeToggle
   repo_url: https://github.com/wiki-gg-oss/mediawiki-extensions-ThemeToggle
 Tilesheets:


### PR DESCRIPTION
main is the unstable development branch, and there is no branch that targets 1.44, so `_branch_` can't be used.