### PR TITLE
Remove MediaSearch

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -670,10 +670,6 @@ MatomoAnalytics:
   branch: main
   path: extensions/MatomoAnalytics
   repo_url: https://github.com/miraheze/MatomoAnalytics
-MediaSearch:
-  branch: _branch_
-  path: extensions/MediaSearch
-  repo_url: https://github.com/wikimedia/mediawiki-extensions-MediaSearch
 MediaSpoiler:
   branch: _branch_
   path: extensions/MediaSpoiler


### PR DESCRIPTION
Not in ManageWikiSettings or used in any other way.