### PR TITLE
T15043: Only apply GlobalUserPage patch on 1.45

### DIFF
--- a/patches/public.json
+++ b/patches/public.json
@@ -16,7 +16,7 @@
 	{
 		"file": "globaluserpage-limit-jobs.patch",
 		"public": true,
-		"versions": [ "all" ],
+		"versions": [ "1.45" ],
 		"path": "extensions/GlobalUserPage",
 		"failureStrategy": "abort"
 	},


### PR DESCRIPTION
The fix will be part of 1.46 in the upstream repo.