### PR TITLE
Use release branch for SimpleBlogPage

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1071,7 +1071,7 @@ SimpleBatchUpload:
   path: extensions/SimpleBatchUpload
   repo_url: https://github.com/ProfessionalWiki/SimpleBatchUpload
 SimpleBlogPage:
-  branch: master
+  branch: _branch_
   path: extensions/SimpleBlogPage
   repo_url: https://github.com/wikimedia/mediawiki-extensions-SimpleBlogPage
   composer: true


### PR DESCRIPTION
OOJSPlus uses the release branch as well and the dependencies are conflicting now.