### PR TITLE
Remove WikiPoints extension from mediawiki-repos.yaml

### DIFF
--- a/mediawiki-repos.yaml
+++ b/mediawiki-repos.yaml
@@ -1367,11 +1367,6 @@ WikiLove:
   branch: _branch_
   path: extensions/WikiLove
   repo_url: https://github.com/wikimedia/mediawiki-extensions-WikiLove
-WikiPoints:
-  branch: main
-  path: extensions/WikiPoints
-  repo_url: https://github.com/Tali64/WikiPoints
-  commit: 9526b6d
 WikiSEO:
   branch: master
   path: extensions/WikiSEO


### PR DESCRIPTION
Will still exist on servers until it's removed later.